### PR TITLE
change list to tuple for button color to prevent errors

### DIFF
--- a/cblaster/gui/main.py
+++ b/cblaster/gui/main.py
@@ -200,8 +200,8 @@ main_gui_layout = [
         [sg.Tab("Citation", [[Column(citation.layout, scrollable=True)]])],
     ], enable_events=True, key="cblaster_tabs"
     )],
-    [sg.Button("Start", key="start_button", button_color=["white", "green"]),
-     sg.Button("Exit", key="exit_button", button_color=["white", "red"])],
+    [sg.Button("Start", key="start_button", button_color=("white", "green")),
+     sg.Button("Exit", key="exit_button", button_color=("white", "red"))],
 ]
 
 
@@ -267,7 +267,7 @@ def create_command_window():
         [sg.Text("Cameron Gilchrist, 2020", font="Arial 10", pad=(0, 0))],
         [sg.Multiline(default_text="Welcome to cblaster", key="textbox", size=(500, 45),
                       disabled=True, autoscroll=True)],
-        [sg.Button("Exit", key="exit_button", button_color=["white", "red"])],
+        [sg.Button("Exit", key="exit_button", button_color=("white", "red"))],
     ]
     command_window = sg.Window(
         "cblaster command",


### PR DESCRIPTION
was getting errors (W10, Python 3.9) on open when button colours were set with lists (e.g. ['white', 'red'])