### PR TITLE
Add config module

### DIFF
--- a/cblaster/config.py
+++ b/cblaster/config.py
@@ -1,0 +1,67 @@
+import configparser
+import appdirs
+import logging
+
+from pathlib import Path
+
+
+LOG = logging.getLogger(__name__)
+
+
+def get_config_dir():
+    path = appdirs.user_config_dir(appname="cblaster", appauthor="gamcil")
+    return Path(path)
+
+
+def get_config_parser():
+    # Get configuration directory, platform agnostic
+    config_dir = get_config_dir()
+    if not config_dir.is_dir():
+        raise IOError("No configuration folder detected, please run cblaster config")
+
+    # Check if there's an existing config.ini
+    config_ini = config_dir / "config.ini"
+    if not config_ini.exists():
+        raise IOError("config.ini not found, please run cblaster config")
+
+    # Read in the configuration values and return the parser
+    config_parser = configparser.ConfigParser()
+    config_parser.read(config_ini)
+    return config_parser
+
+
+def write_config_file(**kwargs):
+    LOG.info("Starting config module")
+
+    if not kwargs:
+        raise IOError("No arguments given")
+
+    config_dir = get_config_dir()
+
+    # Make directory, if it doesn't exist
+    if not config_dir.is_dir():
+        LOG.info("No config directory found, creating %s", config_dir)
+        config_dir.mkdir()
+
+    # Initialise the ConfigParser object
+    config_ini = config_dir / "config.ini"
+    config_parser = configparser.ConfigParser()
+
+    # Read in any config that already exists
+    if config_ini.exists():
+        LOG.info("Found existing configuration file, reading")
+        config_parser.read(config_ini)
+    else:
+        LOG.info("No configuration file found, creating")
+        config_parser["cblaster"] = {}
+
+    # Set new values
+    for key, value in kwargs.items():
+        config_parser["cblaster"][key] = value
+
+    # Write new config file
+    LOG.info("Writing configuration to %s", config_ini)
+    with config_ini.open("w") as cfg:
+        config_parser.write(cfg)
+
+    LOG.info("Done!")

--- a/cblaster/config.py
+++ b/cblaster/config.py
@@ -9,7 +9,7 @@ LOG = logging.getLogger(__name__)
 
 
 def get_config_dir():
-    path = appdirs.user_config_dir(appname="cblaster", appauthor="gamcil")
+    path = appdirs.user_config_dir(appname="cblaster")
     return Path(path)
 
 
@@ -41,7 +41,7 @@ def write_config_file(**kwargs):
     # Make directory, if it doesn't exist
     if not config_dir.is_dir():
         LOG.info("No config directory found, creating %s", config_dir)
-        config_dir.mkdir()
+        config_dir.mkdir(parents=True)
 
     # Initialise the ConfigParser object
     config_ini = config_dir / "config.ini"

--- a/cblaster/config.py
+++ b/cblaster/config.py
@@ -57,7 +57,9 @@ def write_config_file(**kwargs):
 
     # Set new values
     for key, value in kwargs.items():
-        config_parser["cblaster"][key] = value
+        if not value:
+            continue
+        config_parser["cblaster"][key] = str(value)
 
     # Write new config file
     LOG.info("Writing configuration to %s", config_ini)

--- a/cblaster/context.py
+++ b/cblaster/context.py
@@ -32,7 +32,6 @@ from collections import defaultdict, namedtuple
 from itertools import combinations, product
 from operator import attrgetter
 from functools import partial
-from urllib.error import HTTPError
 
 import requests
 import numpy as np

--- a/cblaster/context.py
+++ b/cblaster/context.py
@@ -32,9 +32,12 @@ from collections import defaultdict, namedtuple
 from itertools import combinations, product
 from operator import attrgetter
 from functools import partial
+from urllib.error import HTTPError
 
 import requests
 import numpy as np
+
+from Bio import Entrez
 
 from cblaster import database
 from cblaster.classes import Organism, Scaffold, Subject
@@ -56,36 +59,26 @@ def efetch_IPGs(ids, output_file=None):
     Returns:
         List of rows from resulting IPG table, split by newline.
     """
-
-    # Split into chunks since retmax=10000
-    chunks = [ids[i: i + 10000] for i in range(0, len(ids), 10000)]
-
-    table = ""
-    for ix, chunk in enumerate(chunks, 1):
-        response = requests.post(
-            "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?",
-            params={
-                "db": "protein",
-                "rettype": "ipg",
-                "retmode": "text",
-                "retmax": 10000,
-            },
-            data={"id": ",".join(chunk)},
+    table = []
+    for start in range(0, len(ids), 10000):
+        chunk = ids[start: start + 10000]
+        fetch = Entrez.efetch(
+            "protein",
+            rettype="ipg",
+            retmode="text",
+            id=chunk,
+            retmax=10000,
         )
-
-        if response.status_code != 200:
-            raise requests.HTTPError(
-                f"Error fetching sequences from NCBI [code {response.status_code}]."
-            )
-
-        table += response.text
+        lines = [line.decode() for line in fetch.readlines()]
+        table.extend(lines)
 
     if output_file:
         LOG.info("Writing IPG table to %s", output_file)
-        with open(output_file, "w") as f:
-            f.write(table)
+        with open(output_file, "w") as fp:
+            for line in table:
+                fp.write(line)
 
-    return table.split("\n")
+    return table
 
 
 def parse_IP_groups(results):

--- a/cblaster/context.py
+++ b/cblaster/context.py
@@ -62,13 +62,17 @@ def efetch_IPGs(ids, output_file=None):
     table = []
     for start in range(0, len(ids), 10000):
         chunk = ids[start: start + 10000]
-        fetch = Entrez.efetch(
-            "protein",
-            rettype="ipg",
-            retmode="text",
-            id=chunk,
-            retmax=10000,
-        )
+        try:
+            fetch = Entrez.efetch(
+                "protein",
+                rettype="ipg",
+                retmode="text",
+                id=chunk,
+                retmax=10000,
+            )
+        except IOError:
+            LOG.exception("Network error while retrieving genomic context")
+            raise
         lines = [line.decode() for line in fetch.readlines()]
         table.extend(lines)
 

--- a/cblaster/genome_parsers.py
+++ b/cblaster/genome_parsers.py
@@ -55,11 +55,6 @@ def find_fasta(gff_path):
             return path
 
 
-def parse_fasta_str(fasta):
-    with io.StringIO(fasta) as fp:
-        return list(SeqIO.parse(fp, "fasta"))
-
-
 def parse_fasta(path):
     with open(path) as fp:
         return list(SeqIO.parse(fp, "fasta"))

--- a/cblaster/gui/config.py
+++ b/cblaster/gui/config.py
@@ -1,0 +1,30 @@
+import PySimpleGUI as sg
+
+from cblaster.gui.parts import TextLabel, TEXT_WIDTH
+
+
+sg.theme("Lightgrey1")
+
+
+config_frame = sg.Frame(
+    "Config",
+    layout=[
+        [sg.Text(
+            "This module will allow you to configure cblaster. "
+            "At the moment, this is mostly used so that you can identify "
+            "yourself to the NCBI before using their services. This is an "
+            "anti-abuse measure to prevent people from submitting too many "
+            "queries at a time (>3 per second, or >10 per second with an API key). "
+            "This module must be run before you can do a remote cblaster search.",
+            size=(TEXT_WIDTH, 6)
+        )],
+        [TextLabel("E-mail address"), sg.InputText(size=(34, 1), key="email")],
+        [TextLabel("NCBI API Key"), sg.InputText(size=(34, 1), key="api_key")],
+        [TextLabel("Maximum retries"), sg.InputText(size=(34, 1), key="max_tries")],
+    ],
+    title_color="blue",
+    font="Arial 10 bold",
+    relief="flat",
+)
+
+layout = [[config_frame]]

--- a/cblaster/gui/main.py
+++ b/cblaster/gui/main.py
@@ -9,7 +9,16 @@ from queue import Queue, Empty
 import PySimpleGUI as sg
 
 from cblaster import __version__
-from cblaster.gui import search, makedb, citation, gne, extract, extract_clusters, plot_clusters
+from cblaster.gui import (
+    search,
+    makedb,
+    citation,
+    gne,
+    extract,
+    extract_clusters,
+    plot_clusters,
+    config,
+)
 
 
 sg.theme("Lightgrey1")
@@ -40,7 +49,7 @@ def run_cblaster(values, textbox):
         args = dict(
             query_file=values["query_file"],
             query_ids=values["query_ids"],
-            query_profiles=values["query_profiles"].split(" "),
+            query_profiles=values["query_profiles"],
             session_file=values["session_file"],
             mode=values["search_mode"],
             gap=values["gap"],
@@ -179,9 +188,18 @@ def run_cblaster(values, textbox):
             scaffolds=values["scaffolds pc"],
         )
         subcommand = "plot_clusters"
+    elif values["cblaster_tabs"] == "Config":
+        args = dict(
+            email=values["email"],
+            api_key=values["api_key"],
+            max_tries=values["max_tries"],
+        )
+        subcommand = "config"
     else:
-        raise ValueError("Expected 'Search', 'Makedb', 'Neighbourhood', 'Extract', 'Extract Clusters' or"
-                         " 'Plot Clusters'")
+        raise ValueError(
+            "Expected 'Search', 'Makedb', 'Neighbourhood', 'Extract', "
+            "'Extract Clusters', 'Plot Clusters' or 'Config'"
+        )
 
     return create_cblaster_command(subcommand, args, textbox)
 
@@ -197,6 +215,7 @@ main_gui_layout = [
         [sg.Tab("Extract", [[Column(extract.layout, scrollable=True)]])],
         [sg.Tab("Extract Clusters", [[Column(extract_clusters.layout, scrollable=True)]])],
         [sg.Tab("Plot Clusters", [[Column(plot_clusters.layout, scrollable=True)]])],
+        [sg.Tab("Config", [[Column(config.layout, scrollable=True)]])],
         [sg.Tab("Citation", [[Column(citation.layout, scrollable=True)]])],
     ], enable_events=True, key="cblaster_tabs"
     )],
@@ -206,7 +225,6 @@ main_gui_layout = [
 
 
 def cblaster_gui():
-
     main_window = sg.Window(
         "cblaster",
         main_gui_layout,
@@ -239,7 +257,15 @@ def cblaster_gui():
         # Disable start button when on citation tab
         main_window["start_button"].update(
             disabled=values["cblaster_tabs"]
-            not in ("Search", "Makedb", "Neighbourhood", "Extract", "Extract Clusters", "Plot Clusters")
+            not in (
+                "Search",
+                "Makedb",
+                "Neighbourhood",
+                "Extract",
+                "Extract Clusters",
+                "Plot Clusters",
+                "Config",
+            )
         )
 
         if event == "start_button":
@@ -345,6 +371,8 @@ def create_cblaster_command(subcommand, arguments, textbox):
         elif "blank" in key:
             command += f" {value}"
         else:
+            if isinstance(value, list):
+                value = " ".join(value)
             command += f" --{key} {value}"
     return CommandThread(command, textbox)
 

--- a/cblaster/main.py
+++ b/cblaster/main.py
@@ -514,7 +514,11 @@ def main():
         )
 
     elif args.subcommand == "config":
-        config.write_config_file(email=args.email)
+        config.write_config_file(
+            email=args.email,
+            api_key=args.api_key,
+            max_tries=args.max_tries,
+        )
 
 
 if __name__ == "__main__":

--- a/cblaster/main.py
+++ b/cblaster/main.py
@@ -6,18 +6,20 @@ import sys
 
 from pathlib import Path
 
+from Bio import Entrez
 
 from cblaster import (
+    config,
     context,
     database,
-    helpers,
-    local,
-    remote,
-    parsers,
     extract,
     extract_clusters,
-    plot_clusters,
+    helpers,
     hmm_search,
+    local,
+    parsers,
+    plot_clusters,
+    remote,
 )
 from cblaster.classes import Session
 from cblaster.plot import plot_session, plot_gne
@@ -288,6 +290,15 @@ def cblaster(
 
         elif mode == "remote":
             LOG.info("Starting cblaster in remote mode")
+
+            # Set up mandatory Entrez params
+            cfg = config.get_config_parser()
+            Entrez.email = cfg["cblaster"].get("email", None)
+            Entrez.api_key = cfg["cblaster"].get("api_key", None)
+
+            if not Entrez.email and not Entrez.api_key:
+                raise IOError("No e-mail or NCBI API key found, please run cblaster config")
+
             if entrez_query:
                 session.params["entrez_query"] = entrez_query
             rid, results = remote.search(
@@ -501,6 +512,9 @@ def main():
             max_clusters=args.maximum_clusters,
             testing=args.testing,
         )
+
+    elif args.subcommand == "config":
+        config.write_config_file(email=args.email)
 
 
 if __name__ == "__main__":

--- a/cblaster/parsers.py
+++ b/cblaster/parsers.py
@@ -767,6 +767,36 @@ def add_plot_clusters_subparser(subparsers):
     )
 
 
+def add_config_subparser(subparsers):
+    desc = "Configure cblaster"
+    parser = subparsers.add_parser(
+        "config",
+        help=desc,
+        description="Configure cblaster (e.g. for setting NCBI e-mail addresses or API keys)",
+        epilog=(
+            "Example usage\n-------------\n"
+            "Set an e-mail address:\n"
+            " $ cblaster config --email \"foo@bar.com\"\n\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--email",
+        help="Your e-mail address, required by NCBI to prevent abuse",
+        type=str,
+    )
+    parser.add_argument(
+        "--api_key",
+        help="NCBI API key",
+        type=str,
+    )
+    parser.add_argument(
+        "--max_tries",
+        help="How many times failed requests are retried (def. 3)",
+        type=int,
+    )
+
+
 def get_parser():
     parser = argparse.ArgumentParser(
         "cblaster",
@@ -798,6 +828,7 @@ def get_parser():
     add_extract_subparser(subparsers)
     add_extract_clusters_subparser(subparsers)
     add_plot_clusters_subparser(subparsers)
+    add_config_subparser(subparsers)
     return parser
 
 
@@ -809,7 +840,15 @@ def parse_args(args):
         parser.print_help()
         raise SystemExit
 
-    if arguments.subcommand in ("gui", "makedb", "gne", "extract", "extract_clusters", "plot_clusters"):
+    if arguments.subcommand in (
+        "gui",
+        "makedb",
+        "gne",
+        "extract",
+        "extract_clusters",
+        "plot_clusters",
+        "config",
+    ):
         return arguments
 
     if getattr(arguments, "query_file") and getattr(arguments, "query_ids"):

--- a/docs/source/guide/config.rst
+++ b/docs/source/guide/config.rst
@@ -1,0 +1,29 @@
+.. _config_module:
+
+Pre-search configuration using the ``config`` module
+====================================================
+
+The NCBI requires that you provide some identification before using their
+services in order to prevent abuse. This can be an e-mail address, or more recently,
+an API key (https://ncbiinsights.ncbi.nlm.nih.gov/2017/11/02/new-api-keys-for-the-e-utilities/).
+
+You can use the ``config`` module to set these parameters for ``cblaster`` searches (you'll only have to do this once!).
+This module will save a file, ``config.ini``, wherever your operating system stores configuration
+files (for example, in Linux it will be saved in ~/.local/config/cblaster).
+When you run remote searches in ``cblaster``, it will first check to see if it can find
+this file, and then if an e-mail address or API key is saved; if they are not found,
+``cblaster`` will throw an error.
+
+To set an e-mail address:
+
+::
+
+        $ cblaster config --email "foo@bar.com"
+
+
+...or an API key:
+
+::
+
+        $ cblaster config --api_key <your API key>
+

--- a/docs/source/guide/index.rst
+++ b/docs/source/guide/index.rst
@@ -22,6 +22,7 @@ Table of Contents
 
 	what_is_cblaster
 	installation
+        config_module
 	search_module
 	makedb_module
 	gne_module

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         "Biopython",
         "clinker>=0.0.15",
         "gffutils",
+        "appdirs"
     ],
     tests_require=["pytest", "pytest-cov", "pytest-mock", "requests-mock"],
     python_requires=">=3.6",


### PR DESCRIPTION
Adds a module, `config`, for saving user configuration data locally (cross platform via `appdirs` package). Mainly for saving an email address/API key before accessing NCBI Entrez services, but could potentially extend later. Should be run (only once is necessary) before performing any remote cblaster searches - `cblaster` will throw an exception if it can't find a config folder (e.g. `~/.config/cblaster`), `config.ini` (e.g. `~/.config/cblaster/config.ini`) or if they exist, but no email/API key is saved.