### PR TITLE
Bug fixes, code enhancements, and file compression

### DIFF
--- a/cblaster/database.py
+++ b/cblaster/database.py
@@ -122,7 +122,7 @@ def query_nucleotides(scaffold, organism, start, end, database):
     return _query(query, database, values=[scaffold, organism], fetch="one")
 
 
-def diamond_makedb(fasta, name):
+def diamond_makedb(fasta, name, cpus):
     """Builds a DIAMOND database
 
     Args:
@@ -131,7 +131,7 @@ def diamond_makedb(fasta, name):
     """
     diamond = helpers.get_program_path(["diamond", "diamond-aligner"])
     subprocess.run(
-        [diamond, "makedb", "--in", str(fasta), "--db", name],
+        [diamond, "makedb", "--in", str(fasta), "--db", name, "--threads", str(cpus)],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
@@ -222,6 +222,6 @@ def makedb(paths, database, force=False, cpus=None, batch=None):
     sqlite_to_fasta(fasta_path, sqlite_path)
 
     LOG.info("Building DIAMOND database at %s", dmnd_path)
-    diamond_makedb(fasta_path, dmnd_path)
+    diamond_makedb(fasta_path, dmnd_path, cpus)
 
     LOG.info("Done!")

--- a/cblaster/database.py
+++ b/cblaster/database.py
@@ -2,6 +2,7 @@
 This module handles creation of local JSON databases for non-NCBI lookups.
 """
 
+import os
 import logging
 import subprocess
 import sqlite3
@@ -182,7 +183,14 @@ def makedb(paths, database, force=False, cpus=None, batch=None):
 
     paths = gp.find_files(paths)
     if len(paths) == 0:
-        raise RuntimeError("No valid files provided expected genbank, embl or gff with accompanying fasta file.")
+        raise RuntimeError("No valid files provided expected genbank, embl or gff with accompanying fasta file. Alternatively, provide one .txt file with one file per line.")
+
+    # If a text file was provided, read and parse
+    if len(paths)==1 and os.path.splitext(paths[0])[1] == ".txt":
+        with open(paths[0]) as f:
+            lines = f.read().splitlines()
+        paths = gp.find_files(lines)
+
     total_paths = len(paths)
     if batch is None:
         batch = total_paths

--- a/cblaster/formatters.py
+++ b/cblaster/formatters.py
@@ -61,7 +61,10 @@ def get_cell_values(queries, subjects, key=len, attr=None):
             for hit in subject.hits
             if hit.query == query
         ]
-        result[index] = key(values)
+        if len(values) > 0:
+            result[index] = key(values)
+        else:
+          result[index] = 0  
     return result
 
 

--- a/cblaster/genome_parsers.py
+++ b/cblaster/genome_parsers.py
@@ -1,3 +1,4 @@
+import os
 import functools
 import warnings
 import logging
@@ -20,6 +21,7 @@ FASTA_SUFFIXES = (".fa", ".fsa", ".fna", ".fasta", ".faa")
 GBK_SUFFIXES = (".gbk", ".gb", ".genbank", ".gbf", ".gbff")
 GFF_SUFFIXES = (".gtf", ".gff", ".gff3")
 EMBL_SUFFIXES = (".embl", ".emb")
+LIST_SUFFIXES = (".txt")
 
 
 def find_overlapping_location(feature, locations):
@@ -168,17 +170,20 @@ def parse_gff(path):
 
 def find_files(paths, recurse=True, level=0):
     files = []
-    for path in paths:
-        _path = Path(path)
-        if _path.is_dir():
-            if level == 0 or recurse:
-                _files = find_files(_path.iterdir(), recurse=recurse, level=level + 1)
-                files.extend(_files)
-        else:
-            ext = _path.suffix.lower()
-            valid = ext in GBK_SUFFIXES + GFF_SUFFIXES + EMBL_SUFFIXES
-            if _path.exists() and valid:
-                files.append(_path)
+    if len(paths)==1 and os.path.splitext(paths[0])[1] in LIST_SUFFIXES:
+        files.append(paths[0])
+    else:
+        for path in paths:
+            _path = Path(path)
+            if _path.is_dir():
+                if level == 0 or recurse:
+                    _files = find_files(_path.iterdir(), recurse=recurse, level=level + 1)
+                    files.extend(_files)
+            else:
+                ext = _path.suffix.lower()
+                valid = ext in GBK_SUFFIXES + GFF_SUFFIXES + EMBL_SUFFIXES
+                if _path.exists() and valid:
+                    files.append(_path)
     return files
 
 

--- a/cblaster/helpers.py
+++ b/cblaster/helpers.py
@@ -18,7 +18,10 @@ LOG = logging.getLogger(__name__)
 
 
 def find_sqlite_db(path):
-    sqlite_db = Path(path).with_suffix(".sqlite3")
+    sqlite_db = Path(path)
+    if sqlite_db.suffix == ".gz":
+        sqlite_db = sqlite_db.with_suffix("")
+    sqlite_db = sqlite_db.with_suffix(".sqlite3")
     if not sqlite_db.exists():
         LOG.error("Could not find matching SQlite3 database, exiting")
         raise SystemExit

--- a/cblaster/hmm_search.py
+++ b/cblaster/hmm_search.py
@@ -158,7 +158,10 @@ def run_hmmsearch(fasta, query):
             check=True,
         )
     except subprocess.CalledProcessError:
-        LOG.exception("hmmsearch failed!")
+        add_msg=""
+        if fasta.endswith("gz"):
+            add_msg = " Try running:  \n  gunzip {0} \nand then resubmit your cblaster command command, specifying:\n  -db {1}.\n\n".format(fasta, fasta.replace(".gz",""))
+        LOG.exception("hmmsearch failed!"+add_msg)
     return output
 
 

--- a/cblaster/local.py
+++ b/cblaster/local.py
@@ -45,6 +45,7 @@ def diamond(
     max_evalue=0.01,
     min_identity=30,
     min_coverage=50,
+    hitlist_size=5000,
     cpus=None,
     sensitivity='fast',
 ):
@@ -56,6 +57,7 @@ def diamond(
         max_evalue (float): Maximum e-value threshold
         min_identity (float): Minimum identity (%) cutoff
         min_coverage (float): Minimum coverage (%) cutoff
+        hitlist_size (int): Maximum number of hits to save
         cpus (int): Number of CPU threads for DIAMOND to use
     Returns:
         list: Rows from DIAMOND search result table (split by newline)
@@ -86,6 +88,7 @@ def diamond(
         "--threads": str(cpus),
         "--query-cover": str(min_coverage),
         "--max-hsps": "1",
+        "--max-target-seqs": str(hitlist_size),
     }
 
     if sensitivity != "fast":
@@ -122,6 +125,7 @@ def search(
     min_identity=30,
     min_coverage=50,
     max_evalue=0.01,
+    hitlist_size=5000,
     **kwargs,
 ):
     """Launch a new BLAST search using either DIAMOND or command-line BLASTp (remote).
@@ -141,9 +145,11 @@ def search(
         table = diamond(
             query_file,
             database,
+            sensitivity=dmnd_sensitivity,
             min_identity=min_identity,
             min_coverage=min_coverage,
             max_evalue=max_evalue,
+            hitlist_size=hitlist_size,
             **kwargs
         )
     else:
@@ -164,6 +170,7 @@ def search(
                 min_identity=min_identity,
                 min_coverage=min_coverage,
                 max_evalue=max_evalue,
+                hitlist_size=hitlist_size,
                 **kwargs
             )
         finally:

--- a/cblaster/main.py
+++ b/cblaster/main.py
@@ -291,6 +291,7 @@ def cblaster(
                 blast_file=blast_file,
                 cpus=cpus,
                 dmnd_sensitivity=dmnd_sensitivity,
+                hitlist_size=hitlist_size,
             )
             LOG.info(
                 "Found %i hits meeting score thresholds for local search", len(results)

--- a/cblaster/parsers.py
+++ b/cblaster/parsers.py
@@ -91,7 +91,8 @@ def add_makedb_subparser(subparsers):
     makedb.add_argument(
         "paths",
         type=lambda x: full_path(x, os.R_OK),
-        help="Path/s to genome files to use when building local databases. Alternatively, path to one .txt file with one genome file per line.",
+        help="Path/s to genome files to use when building local databases (can be gzipped). "
+             "Alternatively, path to one .txt file with one genome file per line.",
         nargs="+",
     )
     makedb.add_argument(

--- a/cblaster/parsers.py
+++ b/cblaster/parsers.py
@@ -91,7 +91,7 @@ def add_makedb_subparser(subparsers):
     makedb.add_argument(
         "paths",
         type=lambda x: full_path(x, os.R_OK),
-        help="Path/s to genome files to use when building local databases",
+        help="Path/s to genome files to use when building local databases. Alternatively, path to one .txt file with one genome file per line.",
         nargs="+",
     )
     makedb.add_argument(

--- a/cblaster/parsers.py
+++ b/cblaster/parsers.py
@@ -339,7 +339,7 @@ def add_searching_group(search):
         "--hitlist_size",
         type=int,
         default=5000,
-        help="Maximum total hits to save from a remote BLAST search (def. 5000). Setting"
+        help="Maximum total hits to save from a local or remote BLAST search (def. 5000). Setting"
              " this value too low may result in missed hits/clusters."
     )
     group.add_argument(

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,8 @@ setup(
         "Biopython",
         "clinker>=0.0.15",
         "gffutils",
-        "appdirs"
+        "appdirs",
+        "genomicsqlite"
     ],
     tests_require=["pytest", "pytest-cov", "pytest-mock", "requests-mock"],
     python_requires=">=3.6",


### PR DESCRIPTION
The following pull request does the following:

**Bug fixes:**
- By default, diamond blastp only saves a maximum of 25 hits per query, severely limiting the number of blast hits reported. Large databases are especially impacted. To solve this, the `--hitlist_size` is now passed on `diamond` inside `cblaster search -m local`. (1c16caa) (See issue #75)
- Added an option to `cblaster makedb` allowing users to provide a single `txt` file containing a list of input files. This solves the issue where the operating system limits the length of wildcard expansion on the command line. (bb9085c)
- Fixed error that arose when specifying `sum` or `max` for `-bkey` (fee315e) (see issue #76, thanks to @chasemc)

**Enhancements:**
- `diamond makedb` now uses the number of CPUs requested by the user (instead of all available CPUs) (0db55cc)

**File compression:**
- Use genomcsqlite3 to reduce the size of the final sqlite3 database by 40-60% (bae6b31)
- `cblaster makedb` accepts gzipped input files (241894d)
- `cblaster makedb` now writes a fasta.gz output file (241894d) and informs users they will need to decompress first if running `hmmsearch` (4c63fa5)