### PR TITLE
IndexError fix when no hits are found in a scaffold

### DIFF
--- a/cblaster/context.py
+++ b/cblaster/context.py
@@ -496,8 +496,11 @@ def filter_session(
                 unique=unique,
                 percentage=percentage,
             )
-            scaffold.clusters = []
-            scaffold.add_clusters(clusters, query_sequence_order=session.queries)
+            if len(scaffold.subjects) == 0:  # indicates no hits in clusters and we should not attempt to call scaffold.add_clusters as this would fail
+                LOG.info('No hits found in scaffold {}'.format(scaffold.accession))
+            else:
+                scaffold.clusters = []
+                scaffold.add_clusters(clusters, query_sequence_order=session.queries)
         deduplicate(organism)
 
 


### PR DESCRIPTION
Hits are attempted to be clustered but fails when no hits are found in a scaffold. Implemented a fix to check if there are hits within the scaffolds and if not, do not attempt to cluster hits.