### PR TITLE
Fix GenBank parsing when first gene wraps chromosome start/end

### DIFF
--- a/cblaster/genome_parsers.py
+++ b/cblaster/genome_parsers.py
@@ -246,15 +246,15 @@ def iter_overlapping_features(features):
 
     sorted_features = sorted(features, key=lambda f: f.location.start)
     first = sorted_features.pop(0)
-    group, border = [first], first.location.end
+    group, border = [first], first.location.parts[-1].end
 
     for feature in sorted_features:
         if feature.location.end <= border:
             group.append(feature)
-            border = max(border, feature.location.end)
+            border = max(border, feature.location.parts[-1].end)
         else:
             yield group
-            group, border = [feature], feature.location.end
+            group, border = [feature], feature.location.parts[-1].end
     yield group
 
 


### PR DESCRIPTION
Currently, cblaster does not correctly parse GenBank files if the first gene wraps around the start/end of the chromosome as in this case `first.location` in `iter_overlapping_features` is a compound location.

For example, when adding the following to `iter_overlapping_features` and using such a GenBank file:
```
print(first.location, first.location.end)
```
This is the output:
```
join{[3755448:3756046](+), [0:374](+)} 3756046
```
Since `border` is now almost at the end of the chromosome basically all genes are added to this group of overlapping features, leading to only very few genes in the final list. I believe this is also what's happening in https://github.com/gamcil/cblaster/issues/100.