### PR TITLE
Don't add empty sequences to DB so diamond does not fail

### DIFF
--- a/cblaster/genome_parsers.py
+++ b/cblaster/genome_parsers.py
@@ -69,7 +69,7 @@ def find_gene_name(qualifiers):
 
 def find_translation(record, feature):
     if not feature or "pseudo" in feature.qualifiers:
-        return ""
+        return None
     if "translation" in feature.qualifiers:
         translation = feature.qualifiers.pop("translation", "")
         if isinstance(translation, list):
@@ -276,6 +276,9 @@ def seqrecord_to_tuples(record, source):
         # Get name and translation, prefer CDS instead of gene
         name = find_gene_name(cds.qualifiers if cds else gene.qualifiers)
         translation = find_translation(record, cds)
+
+        if translation is None:
+            continue
 
         # Keep track of record ID and source
         record_id = str(record.id)


### PR DESCRIPTION
Diamond database creation silently fails when generating a local cblaster database if pseudogenes or other genes without a translation are present in the GenBank file. This is because these genes are still added to the database but with an empty sequence. Removing them from the database entirely prevents diamond from failing and should fix https://github.com/gamcil/cblaster/issues/120 (and maybe some cases in https://github.com/gamcil/cblaster/issues/91).